### PR TITLE
Make PUT request to hue bridge on new email

### DIFF
--- a/lib/hue.rb
+++ b/lib/hue.rb
@@ -1,8 +1,21 @@
+require "httparty"
+
 class Hue
+  attr_reader :hue_remote_api_ligths_url
+
   def initialize
+    @hue_remote_api_ligths_url = "#{ENV["HUE_URL_WITH_PORT"]}/api/#{ENV["HUE_USERNAME"]}/lights/#{ENV["HUE_LIGHT_ID"]}/state"
   end
 
   def lights_on
-    puts "blink"
+    HTTParty.put(hue_remote_api_ligths_url,
+      body: {
+        on: true,
+        alert: "select"
+      }.to_json,
+      headers: {
+        'Content-Type' => 'application/json'
+      }
+    )
   end
 end

--- a/spec/lib/hue_spec.rb
+++ b/spec/lib/hue_spec.rb
@@ -1,0 +1,21 @@
+require './lib/hue'
+
+RSpec.describe Hue do
+  let(:hue) { Hue.new }
+  before do
+    allow(HTTParty).to receive(:put).and_return(true)
+  end
+
+  context "#new" do
+    it "must set a valid class attributes" do
+      expect(hue.hue_remote_api_ligths_url).not_to be_nil
+    end
+  end
+
+  context "#lights_on" do
+    it "returns true when a new message is present" do
+      expect(HTTParty).to receive(:put)
+      hue.lights_on
+    end
+  end
+end


### PR DESCRIPTION
Setting `alert` to `select` performs a single blink action on the mentioned hue light bulb id. 